### PR TITLE
sha256 is changed

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,6 +1,6 @@
 cask "dbeaver-community" do
   version "21.1.0"
-  sha256 "d8500c45917480c2532db584e0470b9c015abd25a09ce68beafd7a70dba3c3ff"
+  sha256 "dec806a96ea9609e45357ca31685e39495973d22ee1612099b73756cfe740573"
 
   url "https://dbeaver.io/files/#{version}/dbeaver-ce-#{version}-macos.dmg"
   name "DBeaver Community Edition"


### PR DESCRIPTION
`https://download.dbeaver.com/community/21.1.0/checksum/dbeaver-ce-21.1.0-macos.dmg.sha256` content is different.
```bash
==> Purging files for version 21.1.0 of Cask dbeaver-community
Error: dbeaver-community: SHA256 mismatch
Expected: d8500c45917480c2532db584e0470b9c015abd25a09ce68beafd7a70dba3c3ff
  Actual: dec806a96ea9609e45357ca31685e39495973d22ee1612099b73756cfe740573
    File: ../Library/Caches/Homebrew/downloads/b32ade3e2b41e43fddc587ddbcc5fc48e23b6be7de2b69297b4e0b8e17c66134--dbeaver-ce-21.1.0-macos.dmg
To retry an incomplete download, remove the file above.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x ] `brew audit --cask <cask>` is error-free.
- [x ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
